### PR TITLE
fixing pipfile and pipfile.lock

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,11 +12,8 @@ numpy = "*"
 scipy = "*"
 sklearn = "*"
 matplotlib = "*"
-<<<<<<< Updated upstream
 iso639 = "*"
-=======
 seaborn = "*"
->>>>>>> Stashed changes
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,8 @@
 {
     "_meta": {
         "hash": {
-<<<<<<< Updated upstream
             "sha256": "3fd404a0d8253fba6d24708a8c1a62ec11aad4618d2b03443366dd5d05974a4f"
-=======
             "sha256": "c44cc6225e71ad8ea57ba5f1f298204f0b671bf94badcb5ebd5bb3acd9b674dd"
->>>>>>> Stashed changes
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
## Description
This branch fixes the pipfile and pipfile.lock as characters were added when elements of branch were stashed and conflicts not resolved

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Run `pipenv shell` in the repo directory.